### PR TITLE
Updated the configuration file for TravisCI to deploy contents to GitHub Page automatically when the master branch is updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ python:
   - 2.7
 install:
   - pip install --upgrade pip
+  - pip install -r requirements.txt
 script: 
   - make docs
-  - make bwcdocs
+after_success:
+  - scripts/deploy_gh_pages.sh
+branches:
+  only:
+    - master

--- a/scripts/deploy_gh_pages.sh
+++ b/scripts/deploy_gh_pages.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+git clone -b gh-pages https://${GH_TOKEN}@github.com/stackstorm-japan/st2docs.jp.git gh-pages
+
+cd gh-pages
+
+# clear old files and add new files
+rm -fR *
+cp -r ../docs/build/html/* ./
+
+# commit to remote repository on the gh-pages branch
+git add .
+git commit -m "Updates gh-pages because of updating the master branch."
+git push origin gh-pages

--- a/scripts/deploy_gh_pages.sh
+++ b/scripts/deploy_gh_pages.sh
@@ -1,6 +1,21 @@
 #!/bin/sh
 
-git clone -b gh-pages https://${GH_TOKEN}@github.com/stackstorm-japan/st2docs.jp.git gh-pages
+#
+# This script is mainly used by CI to update contents of gh-pages to the latest one.
+#
+
+if [ -z "${GH_TOKEN}" -o -z "${GH_REPO}" ]; then
+  echo '(ERROR) The environment variables "GH_TOKEN" and "GH_REPO" have to be set'
+  exit 1
+fi
+
+# ${GH_TOKEN} is an access token of GitHub to update GitHub pages of the repository
+# which is specified in ${GH_REPO}.
+git clone -b gh-pages https://${GH_TOKEN}@github.com/${GH_REPO}.git gh-pages
+if [ $? -ne 0 ]; then
+  echo "(ERROR) Failed to clone the remote repository from 'https://${GH_TOKEN}@github.com/${GH_REPO}.git'"
+  exit 1
+fi
 
 cd gh-pages
 


### PR DESCRIPTION
## 概要
#4 の対応.

## 変更点
* `make docs` で生成されたコンテンツを GitHub Pages に更新 (`gh-pages` ブランチにコミット) するスクリプト (`scripts/deploy_gh_pages.sh`) を追加
* master ブランチが更新された際に、上記スクリプトを実行するよう TravisCI の設定ファイルを修正